### PR TITLE
Fix windows cross-compile (Setpgid unix-only)

### DIFF
--- a/docs/NextUp.md
+++ b/docs/NextUp.md
@@ -8,17 +8,6 @@ reader (or a future AI session) can pick them up without conversation history.
 
 Small, known-scope items to clear before the next big refactor.
 
-- **Windows cross-compile is broken** (`worker/worker.go:89`, `:92`) —
-  `cmd.SysProcAttr.Setpgid = true` is unix-only. Windows `syscall.SysProcAttr`
-  has no `Setpgid` field, so `GOOS=windows go build` fails with
-  `type *syscall.SysProcAttr has no field or method Setpgid`. Pre-existing
-  latent bug the new CI surfaced on the first post-merge master run. Fix:
-  split the daemon-attrs block into `worker/daemon_unix.go` (with the
-  existing body) and `worker/daemon_windows.go` (no-op — windows has no
-  process groups; the shell already detaches) behind `//go:build` tags,
-  and call a `setDaemonAttrs(cmd)` helper from `Run()`. After this lands,
-  `cross-compile` on master will go green and the release-automation
-  follow-up below can produce all three binaries.
 - **Normalize task-handler error status codes** (`server/serve_tasks.go`) —
   `updateTaskProgress` returns 500 for a missing task id; `markTaskAsFinished`
   returns 400; `claimTask` returns 500 when the worker isn't in the DB.

--- a/worker/daemon_unix.go
+++ b/worker/daemon_unix.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package worker
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setDaemonAttrs puts the spawned worker in its own process group so it
+// survives the parent shell. Unix-only; the windows build provides a
+// no-op stub.
+func setDaemonAttrs(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}

--- a/worker/daemon_windows.go
+++ b/worker/daemon_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package worker
+
+import "os/exec"
+
+// setDaemonAttrs is a no-op on windows: syscall.SysProcAttr has no
+// Setpgid field, and windows has no process-group concept — a detached
+// child already survives the parent shell.
+func setDaemonAttrs(cmd *exec.Cmd) {}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -85,13 +85,7 @@ func (c *WorkerConf) Run() error {
 			cmd.Args = append(cmd.Args, fmt.Sprintf("%f", c.CheckInterval))
 		}
 
-		if cmd.SysProcAttr != nil {
-			cmd.SysProcAttr.Setpgid = true
-		} else {
-			cmdAttrs := &syscall.SysProcAttr{}
-			cmdAttrs.Setpgid = true
-			cmd.SysProcAttr = cmdAttrs
-		}
+		setDaemonAttrs(cmd)
 
 		// FIXME: Redirect the first couple seconds of stdout here to check that process started ok
 		cmd.Start()


### PR DESCRIPTION
## Summary

- `cmd.SysProcAttr.Setpgid = true` in `worker/worker.go` was unix-only;
  windows `syscall.SysProcAttr` has no `Setpgid` field, so
  `GOOS=windows go build` has been failing ever since the CI
  cross-compile job was added.
- Split the daemon-attrs block into `setDaemonAttrs(cmd)` with per-platform
  build tags: unix sets `Setpgid`, windows is a no-op (no process groups
  to manage; child is already sufficiently detached).
- Drops the matching Fix Sooner entry in `docs/NextUp.md`.

## Test plan

- [x] `make docker-build` produces linux, darwin, and windows binaries
- [x] `make docker-test` all packages still PASS
- [x] CI `test` job green
- [x] CI `cross-compile` job green (first time this job will pass on master)

🤖 Generated with [Claude Code](https://claude.com/claude-code)