### PR TITLE
Add examples/types/ with realistic task-type fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ See `Dockerfile` for what the image carries.
 # `make darwin` → ./blanket-darwin-amd64, `make windows` → .exe.
 make linux
 
-# Copy the shipped echo_task fixture so there's a type to exercise. Point
-# your own task-type directory at `./types` for production use.
-cp -r testdata/types ./types
+# Copy the shipped example task types so there's something to exercise.
+# Drop your own TOML files in this directory (or any directory listed in
+# `tasks.typesPaths`) as you build up your own types.
+cp -r examples/types ./types
 
 # Create a config file
 cat > blanket.json <<'EOF'
@@ -60,23 +61,34 @@ curl -s -X GET localhost:8773/task/ | jq .
 ./blanket-linux-amd64 ps
 ```
 
-Submit a task of the shipped `echo_task` type:
+Submit a task of the shipped `echo_task` type (the minimal one — just
+writes a string to stdout):
 
 ```bash
 curl -s -X POST localhost:8773/task/ \
-    -d '{"type": "echo_task", "environment": {"GREETING": "hello"}}'
+    -d '{"type": "echo_task"}'
 ```
 
-Once you've defined your own task types (drop TOML files into `./types/` —
-see `testdata/types/echo_task.toml` for the schema), submit them the same
-way. Environment values are passed through as env vars to the task's command:
+The `bash_task` example takes a `DEFAULT_COMMAND` env var and runs it
+through bash — the generic escape hatch for ad-hoc commands:
 
 ```bash
 curl -s -X POST localhost:8773/task/ \
-    -d '{"type": "bash_task", "environment": {"PANDAS": "four", "Frogs": 5, "CATS": 2}}'
+    -d '{"type": "bash_task", "environment": {"DEFAULT_COMMAND": "echo $(date)"}}'
 curl -X POST localhost:8773/task/ \
     -d '{"type": "bash_task", "environment": {"DEFAULT_COMMAND": "cd ~ && ls -lah"}}'
 ```
+
+The `python_hello` example shells out to `python3` and has an optional
+`NAME` env var with a default:
+
+```bash
+curl -s -X POST localhost:8773/task/ \
+    -d '{"type": "python_hello", "environment": {"NAME": "blanket"}}'
+```
+
+See `examples/types/*.toml` for the schema; drop your own TOML files
+into `./types/` and submit them the same way.
 
 Add a task and upload some data files with it. Files will be placed at the root of the directory where the task runs.
 

--- a/docs/NextUp.md
+++ b/docs/NextUp.md
@@ -74,18 +74,6 @@ effort than a normal test add.
   machine (`WAITING → CLAIMED → RUNNING → SUCCESS/ERROR/STOPPED/TIMEDOUT`),
   the worker claim loop, and the `tailed_file` subscribe/backfill flow.
 
-## Examples
-
-- **Ship more example task types** — `testdata/types/echo_task.toml` is
-  the only fixture today, and it's intentionally minimal (so smoke tests
-  stay fast). Add a couple of realistic examples the README already
-  hints at: a `bash_task` that accepts `DEFAULT_COMMAND` via env, and a
-  `python_hello` that shells out to `python3 -c`. Drop them under
-  `examples/types/` (not `testdata/`, so the smoke suite isn't affected)
-  and point the README's curl snippets at that directory. Helps first-run
-  users feel out the type-definition schema without writing one from
-  scratch.
-
 ## Branding
 
 - **Project branding pass** — pick a logo, color palette, and tagline for

--- a/examples/types/bash_task.toml
+++ b/examples/types/bash_task.toml
@@ -1,0 +1,20 @@
+# Generic bash escape hatch — submitter supplies the command to run in
+# DEFAULT_COMMAND. Good for ad-hoc one-offs (builds, deploys, file
+# munging) where writing a dedicated task type isn't worth it.
+#
+# The {{.VAR}} template syntax references task environment variables at
+# submit time; blanket also exports them as real env vars to the shell,
+# so `$DEFAULT_COMMAND` would work too.
+
+tags = ["bash", "unix"]
+timeout = 300
+
+command = '''
+{{.DEFAULT_COMMAND}}
+'''
+
+executor = "bash"
+
+  [[environment.required]]
+  name = "DEFAULT_COMMAND"
+  description = "The bash command to run. E.g. 'echo $(date)'"

--- a/examples/types/echo_task.toml
+++ b/examples/types/echo_task.toml
@@ -1,0 +1,8 @@
+# Minimal task type — writes a fixed string to stdout, exits 0. Useful as
+# a first-run sanity check ("does my server/worker pair actually run a
+# task?") and as a template for copy-pasting into your own types.
+
+tags = ["bash", "unix"]
+timeout = 10
+command = "echo 'hello from blanket'"
+executor = "bash"

--- a/examples/types/python_hello.toml
+++ b/examples/types/python_hello.toml
@@ -1,0 +1,19 @@
+# Shells out to python3 — a realistic "run a script from the repo"
+# pattern. Shows an optional env var (NAME) with a default, so the task
+# can be submitted with no environment at all.
+#
+# Requires python3 on $PATH; tag "python" keeps it off workers that
+# don't advertise that capability.
+
+tags = ["python", "unix"]
+timeout = 60
+
+command = '''
+python3 -c "print('hello, {{.NAME}}!')"
+'''
+
+executor = "bash"
+
+  [[environment.default]]
+  name = "NAME"
+  value = "world"


### PR DESCRIPTION
## Summary

- Ship three drop-in example task types under `examples/types/` so
  first-run users have a template to copy from: `echo_task` (minimal),
  `bash_task` (generic `$DEFAULT_COMMAND`), and `python_hello` (default
  env + `{{.NAME}}` template substitution).
- Update the README quick-start to `cp -r examples/types ./types` and
  point each curl example at a shipped type that actually exists.
- `testdata/types/echo_task.toml` stays minimal — it's the smoke-test
  fixture and wants to stay fast.

## Test plan

- [x] `make linux` + server + worker + `curl -X POST /task/` with each
      of the three types → all three reach `SUCCESS` with the expected
      stdout
- [x] CI `test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)