### PR TITLE
Add worker detail page with SSE log streaming

### DIFF
--- a/server/serve_logs.go
+++ b/server/serve_logs.go
@@ -28,13 +28,12 @@ func (s *ServerConfig) streamLog(c *gin.Context, sub *tailed_file.TailedFileSubs
 
 		select {
 		case logline := <-sub.NewLines:
-			// Send event with message content
 			timer.Stop()
 			c.Writer.Header()["Content-Type"] = []string{"text/event-stream"}
 			sse.Encode(c.Writer, sse.Event{
 				Id:    strconv.Itoa(lineno),
 				Event: "message",
-				Data:  logline,
+				Data:  logline + "\n",
 			})
 			lineno++
 			loglineChannelIsEmpty = false

--- a/server/serve_workers.go
+++ b/server/serve_workers.go
@@ -254,9 +254,25 @@ func (s *ServerConfig) streamWorkerLog(c *gin.Context) {
 	}
 	defer sub.Stop()
 
-	// Worker is done if it is stopped
 	isComplete := func() bool {
-		return true
+		w, err = s.DB.GetWorker(workerId)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"workerId":       workerId,
+				"subscriptionId": sub.Id,
+				"tailedFile":     sub.TailedFile.Filepath,
+			}).Error("error refreshing worker state while processing logstreaming request")
+			return true
+		}
+		if w.Stopped {
+			log.WithFields(log.Fields{
+				"workerId":       workerId,
+				"subscriptionId": sub.Id,
+				"tailedFile":     sub.TailedFile.Filepath,
+			}).Info("stopping logstreaming request because worker is stopped")
+			return true
+		}
+		return false
 	}
 	s.streamLog(c, sub, isComplete)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -95,6 +95,7 @@ func (s *ServerConfig) GetRouter() *gin.Engine {
 	r.GET("/ui/", s.uiNextTasksPage)
 	r.GET("/ui/tasks/:id", s.uiNextTaskDetailPage)
 	r.GET("/ui/workers", s.uiNextWorkersPage)
+	r.GET("/ui/workers/:id", s.uiNextWorkerDetailPage)
 	r.GET("/ui/task-types", s.uiNextTaskTypesPage)
 	r.GET("/ui/about", s.uiNextAboutPage)
 	r.POST("/ui/tasks", s.uiNextSubmitTask)
@@ -147,7 +148,8 @@ func (s *ServerConfig) GetRouter() *gin.Engine {
 	r.PUT("/worker/:id/restart", s.restartWorker) // re-start an existing worker
 	r.PUT("/worker/:id", s.updateWorker)          // used for initial creation + status updates
 	r.DELETE("/worker/:id", s.deleteWorker)       // remove from database; can only be called on a stopped worker
-	r.GET("/worker/:id/logs", s.getWorkerLogfile) // server sent events
+	r.GET("/worker/:id/logs", s.getWorkerLogfile) // full logfile download
+	r.GET("/worker/:id/log", s.streamWorkerLog)   // SSE stream of worker log
 
 	return r
 }

--- a/server/ui_next.go
+++ b/server/ui_next.go
@@ -199,6 +199,22 @@ func (s *ServerConfig) uiNextWorkersPage(c *gin.Context) {
 	s.renderUINext(c, t, gin.H{"Title": "Workers", "Workers": ws})
 }
 
+// uiNextWorkerDetailPage renders one worker's metadata and log stream.
+func (s *ServerConfig) uiNextWorkerDetailPage(c *gin.Context) {
+	workerId, err := SafeObjectId(c.Param("id"))
+	if err != nil {
+		c.String(http.StatusBadRequest, err.Error())
+		return
+	}
+	w, err := s.DB.GetWorker(workerId)
+	if err != nil {
+		c.String(http.StatusNotFound, err.Error())
+		return
+	}
+	t := mustParseUINextPage("worker-detail", "ui_next/templates/worker_detail.html")
+	s.renderUINext(c, t, gin.H{"Title": "Worker " + workerId.Hex()[:8], "Worker": w})
+}
+
 // uiNextNewWorkerPartial returns the "new worker" form.
 func (s *ServerConfig) uiNextNewWorkerPartial(c *gin.Context) {
 	t := mustParsePartial("new-worker-form", "new_worker_form.html")

--- a/server/ui_next/templates/worker_detail.html
+++ b/server/ui_next/templates/worker_detail.html
@@ -1,0 +1,54 @@
+{{define "content"}}
+<section>
+    <div class="list-header">
+        <h2>Worker Detail</h2>
+        <a class="btn" href="/ui/workers">← Back to Workers</a>
+    </div>
+
+    <h3>Worker · <span class="muted">{{hex .Worker.Id}}</span></h3>
+
+    <table>
+        <thead><tr><th>Setting</th><th>Value</th></tr></thead>
+        <tbody>
+            <tr><td>ID</td><td>{{hex .Worker.Id}}</td></tr>
+            <tr><td>PID</td><td>{{.Worker.Pid}}</td></tr>
+            <tr><td>Tags</td><td>{{join .Worker.Tags ", "}}</td></tr>
+            <tr><td>Started</td><td>{{fmtTs .Worker.StartedTs}}</td></tr>
+            <tr><td>Poll Interval</td><td>{{.Worker.CheckInterval}}s</td></tr>
+            <tr><td>Stopped</td><td>{{if .Worker.Stopped}}yes{{else}}no{{end}}</td></tr>
+            <tr><td>Logfile</td><td class="muted">{{.Worker.Logfile}}</td></tr>
+            <tr><td>Full Log</td><td><a href="/worker/{{hex .Worker.Id}}/logs">Download logfile</a></td></tr>
+            <tr><td>JSON</td><td><a href="/worker/{{hex .Worker.Id}}">JSON representation</a></td></tr>
+        </tbody>
+    </table>
+
+    <h3>Live Log
+        <label style="font-weight:normal;font-size:0.9rem;margin-left:1rem;">
+            <input type="checkbox" id="pin-bottom" checked> Pin to bottom
+        </label>
+    </h3>
+    {{if not .Worker.Stopped}}
+    <pre id="worker-log"
+         hx-ext="sse"
+         sse-connect="/worker/{{hex .Worker.Id}}/log"
+         sse-swap="message"
+         hx-swap="beforeend"
+         style="max-height:420px;overflow:auto;background:#0e1014;color:#d4d4d4;padding:0.75rem;border-radius:6px;"
+         aria-label="live worker log"></pre>
+    <script>
+    (function () {
+      var el = document.getElementById('worker-log');
+      var pin = document.getElementById('pin-bottom');
+      if (!el) return;
+      el.addEventListener('htmx:sseMessage', function () {
+        if (pin.checked) el.scrollTop = el.scrollHeight;
+      });
+    })();
+    </script>
+    {{else}}
+    <p class="muted">Worker is stopped — streaming is disabled. Use the
+        <a href="/worker/{{hex .Worker.Id}}/logs">logfile download</a>
+        link above for the final output.</p>
+    {{end}}
+</section>
+{{end}}

--- a/server/ui_next/templates/workers_rows.html
+++ b/server/ui_next/templates/workers_rows.html
@@ -2,7 +2,7 @@
 {{range $i, $w := .Workers}}
 <tr>
     <th scope="row">{{add $i 1}}</th>
-    <td>{{$w.Pid}}</td>
+    <td><a href="/ui/workers/{{hex $w.Id}}">{{$w.Pid}}</a></td>
     <td>{{join $w.Tags ", "}}</td>
     <td>{{fmtTs $w.StartedTs}}</td>
     <td class="muted">{{$w.Logfile}}</td>

--- a/tests/e2e/specs/journeys.spec.ts
+++ b/tests/e2e/specs/journeys.spec.ts
@@ -239,3 +239,82 @@ test.describe('Workers view', () => {
     await expect(page.getByRole('columnheader', { name: 'Tags' })).toBeVisible();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Worker detail page — metadata table and Live Log section
+// ---------------------------------------------------------------------------
+
+test.describe('Worker detail page', () => {
+  test.skip(skipBrowser, 'SKIP_BROWSER_TESTS=1');
+
+  let workerId: string;
+
+  test.beforeEach(async ({ request }) => {
+    // Register a fake worker via the API so the detail page has data.
+    workerId = require('crypto').randomBytes(12).toString('hex');
+    const res = await request.put(`/worker/${workerId}`, {
+      data: {
+        id: workerId,
+        tags: ['bash', 'unix'],
+        pid: 99999,
+        stopped: false,
+        checkInterval: 2,
+        logfile: '/tmp/test-worker.log',
+        startedTs: Math.floor(Date.now() / 1000),
+      },
+    });
+    expect(res.status()).toBe(200);
+  });
+
+  test.afterEach(async ({ request }) => {
+    // Stop then delete the worker.
+    await request.put(`/worker/${workerId}/stop`);
+    await request.delete(`/worker/${workerId}`);
+  });
+
+  test('shows worker metadata and Live Log heading', async ({ page }) => {
+    await page.goto(`/ui/workers/${workerId}`);
+    await expect(
+      page.getByRole('heading', { name: 'Worker Detail', exact: true }),
+    ).toBeVisible();
+
+    // Metadata table contains the worker ID.
+    await expect(page.getByRole('cell', { name: workerId })).toBeVisible();
+
+    // Tags appear.
+    await expect(page.getByText('bash, unix')).toBeVisible();
+
+    // Live Log section heading is present.
+    await expect(
+      page.getByRole('heading', { name: /Live Log/i }),
+    ).toBeVisible();
+
+    // Back link navigates to workers list.
+    await page.getByRole('link', { name: /Back to Workers/i }).click();
+    await expect(
+      page.getByRole('heading', { name: 'Workers', exact: true }),
+    ).toBeVisible();
+  });
+
+  test('workers list links to detail page', async ({ page }) => {
+    await page.goto('/ui/workers');
+    await page.getByRole('button', { name: /refresh list/i }).click();
+
+    // The PID cell is a link to the detail page.
+    const pidLink = page.getByRole('link', { name: '99999' });
+    await expect(pidLink).toBeVisible();
+    await pidLink.click();
+
+    await expect(
+      page.getByRole('heading', { name: 'Worker Detail', exact: true }),
+    ).toBeVisible();
+  });
+
+  test('stopped worker shows streaming-disabled message', async ({ page, request }) => {
+    await request.put(`/worker/${workerId}/stop`);
+    await page.goto(`/ui/workers/${workerId}`);
+    await expect(
+      page.getByText('Worker is stopped', { exact: false }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- New worker detail page (`/ui/workers/:id`) mirroring the existing task detail page: metadata table, live SSE log stream with auto-scroll, and a "streaming disabled" fallback for stopped workers.
- Fixed `streamWorkerLog` — existed but was unrouted, and its `isComplete` always returned `true` (stream closed immediately). Now checks `worker.Stopped` state, matching the task streaming contract.
- Fixed SSE log newlines — `serve_logs.go` now appends `\n` to each data payload so lines render correctly in the `<pre>`. Fixes both task and worker live log views.
- PID column in workers list now links to the detail page.

## Test plan

- [x] `shows worker metadata and Live Log heading` — detail page renders with correct ID, tags, and Live Log section
- [x] `workers list links to detail page` — PID link navigates to worker detail
- [x] `stopped worker shows streaming-disabled message` — stopped worker shows fallback text
- [x] All existing Go, smoke, and Playwright tests pass (20/20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)