### PR TITLE
Fix nil-pointer panic in claimTask and misleading claim logs

### DIFF
--- a/server/serve_tasks.go
+++ b/server/serve_tasks.go
@@ -142,14 +142,14 @@ func (s *ServerConfig) claimTask(c *gin.Context) {
 	dbt, err := s.DB.GetTask(t.Id)
 	if err != nil {
 		if _, ok := err.(database.ItemNotFoundError); ok {
-			// Not found: ack task, return message saying task was probably deleted from db
 			status := http.StatusNotFound
-			errMsg = fmt.Sprintf("Could not find task in database, it was likely stopped and deleted")
-			if err = ackCb(); err != nil {
-				errMsg = "%s: Encountered error while trying to ack task :: %s"
+			errMsg = "Could not find task in database, it was likely stopped and deleted"
+			if ackErr := ackCb(); ackErr != nil {
+				errMsg = fmt.Sprintf("%s: Encountered error while trying to ack task :: %s", errMsg, ackErr.Error())
 				status = http.StatusInternalServerError
 			}
 			c.String(status, MakeErrorString(errMsg))
+			return
 		}
 
 		errMsg = fmt.Sprintf("Could not fetch task from database to ensure it was not stopped :: %s", err.Error())

--- a/server/serve_tasks_test.go
+++ b/server/serve_tasks_test.go
@@ -13,7 +13,7 @@
 //   - PUT /task/:id/finish: TestFinishTask_Valid, TestFinishTask_MissingTask,
 //     TestFinishTask_WrongState, TestFinishTask_InvalidState
 //   - POST /task/claim/:workerid edges: TestClaim_MissingWorker,
-//     TestClaim_NoMatchingTask
+//     TestClaim_NoMatchingTask, TestClaim_DeletedTaskDoesNotPanic
 //   - claim-task happy path: covered by worker integration test TestProcessOne
 //
 // Not yet covered:
@@ -558,6 +558,38 @@ func TestClaim_NoMatchingTask(t *testing.T) {
 	// Empty queue is a normal polling state — handler returns 204 No Content
 	// so idle workers don't spam error logs.
 	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+func TestClaim_DeletedTaskDoesNotPanic(t *testing.T) {
+	cleanup := setupTestTaskType(t)
+	defer cleanup()
+
+	s, scleanup := NewTestServer()
+	defer scleanup()
+	r := s.GetRouter()
+
+	wconf := worker.WorkerConf{
+		Id:   objectid.NewObjectId(),
+		Tags: []string{"bash", "unix"},
+	}
+	assert.NoError(t, s.DB.UpdateWorker(&wconf))
+
+	created := postTask(r, "echo_task")
+	assert.Equal(t, http.StatusCreated, created.Code)
+	var body struct{ ID string `json:"id"` }
+	json.NewDecoder(created.Body).Decode(&body)
+
+	taskId := objectid.ObjectIdHex(body.ID)
+	assert.NoError(t, s.DB.DeleteTask(taskId))
+
+	url := fmt.Sprintf("/task/claim/%s", wconf.Id.Hex())
+	req, _ := http.NewRequest("POST", url, nil)
+	w := httptest.NewRecorder()
+
+	assert.NotPanics(t, func() {
+		r.ServeHTTP(w, req)
+	})
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 // --- GET /task/ with additional filters ---

--- a/server/serve_tasks_test.go
+++ b/server/serve_tasks_test.go
@@ -576,7 +576,9 @@ func TestClaim_DeletedTaskDoesNotPanic(t *testing.T) {
 
 	created := postTask(r, "echo_task")
 	assert.Equal(t, http.StatusCreated, created.Code)
-	var body struct{ ID string `json:"id"` }
+	var body struct {
+		ID string `json:"id"`
+	}
 	json.NewDecoder(created.Body).Decode(&body)
 
 	taskId := objectid.ObjectIdHex(body.ID)

--- a/tasks/task_client.go
+++ b/tasks/task_client.go
@@ -83,12 +83,21 @@ func MarkAsClaimed(workerId objectid.ObjectId) (Task, error) {
 		return Task{}, nil
 	}
 
-	if res.StatusCode != 200 {
-		// FIXME: Get the error content from the JSON response
+	if res.StatusCode == http.StatusNotFound {
 		errMsg := make(map[string]interface{})
 		dec.Decode(&errMsg)
 		log.WithFields(log.Fields{
 			"resp": errMsg["error"],
+		}).Warn("Claimed task was deleted or stopped before we could process it; will retry")
+		return Task{}, nil
+	}
+
+	if res.StatusCode != 200 {
+		errMsg := make(map[string]interface{})
+		dec.Decode(&errMsg)
+		log.WithFields(log.Fields{
+			"resp":       errMsg["error"],
+			"statusCode": res.StatusCode,
 		}).Error("Problem claiming task")
 		return Task{}, fmt.Errorf("Problem claiming task; status code :: %s", res.Status)
 	}


### PR DESCRIPTION
## Summary

- **Panic fix:** `claimTask` in `serve_tasks.go` had a missing `return` in the `ItemNotFoundError` branch — after `ackCb()` succeeded (setting `err = nil`), the code fell through to `err.Error()` on line 155, triggering a nil-pointer panic on every claim of a task that had been deleted from the DB while queued.
- **Format string fix:** the ack-error path had `%s` placeholders with no arguments.
- **Worker log level:** `task_client.go` now handles 404 specifically — downgrades the log from `Error` to `Warn` since a deleted/stopped task in the queue is a normal race condition, not an operational error. Returns `(Task{}, nil)` so the worker retries cleanly instead of logging a scary error every poll interval.

## Test plan

- [x] `TestClaim_DeletedTaskDoesNotPanic` — creates a task, deletes it from the DB, then claims; asserts no panic + 404 response
- [x] All existing Go, smoke, and Playwright tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)