### PR TITLE
Replace polling with SSE push for tasks/workers lists

### DIFF
--- a/docs/NextUp.md
+++ b/docs/NextUp.md
@@ -56,10 +56,6 @@ effort than a normal test add.
   `softprops/action-gh-release@v2`. "Single binary that drops on any host"
   is a load-bearing promise of the project — release tags should publish
   it automatically.
-- **Branch protection on master** — once the first CI run is green, wire
-  the `test` check as required via `gh api -X PUT
-  repos/turtlemonvh/blanket/branches/master/protection`. See the CI plan
-  for the exact payload.
 - **GHCR push of `blanket-dev:latest`** — currently every CI run rebuilds
   the toolchain image from scratch (GHA layer cache helps, but full cache
   misses cost ~5m). Pushing the image to `ghcr.io/turtlemonvh/blanket-dev`
@@ -91,15 +87,6 @@ The HTMX + Go-template UI is now the only UI (Phase C complete — Angular,
   - Update `lastHeardTs` on stop
   - Allow a `force` option that sends signals on supported platforms
   - `deleteWorker` should validate the worker is stopped before deleting
-- **Consider SSE-based push for workers + tasks lists** — both tbodies
-  currently auto-refresh via `hx-trigger="every 2s"`. Polling is fine
-  for low traffic but every open tab fires a request whether or not
-  anything changed. If this ever becomes a bottleneck (many tabs, slow
-  DB, noisy access logs), swap to an SSE channel that fires a "list
-  changed" event from the mutation paths and have htmx-sse trigger the
-  re-fetch. The streaming endpoint pattern in `server/serve_logs.go` is
-  the reference. Cost: a long-lived connection per tab, plus fan-out on
-  the mutation paths. Polling stays cheaper while open-tab count is small.
 - **Rename `server/ui_next/` → `server/ui/`** and the `uiNext*` funcs to
   drop the migration-era suffix. Pure cosmetic; safe to do any time.
 
@@ -118,5 +105,3 @@ Bigger bodies of work. Pick one when Phase 1 cleanup and test expansion wrap.
 - **Context propagation** — no `context.Context` plumbing anywhere; blocking
   operations can't be cancelled cleanly and timeouts are ad-hoc. Medium-sized
   sweep that touches most handlers and the worker loop.
-- **UI modernization** — listed above under Deferred; also belongs here as a
-  phase candidate if we want to prioritize it.

--- a/server/event_hub.go
+++ b/server/event_hub.go
@@ -1,0 +1,37 @@
+package server
+
+import "sync"
+
+type EventHub struct {
+	mu   sync.Mutex
+	subs map[chan struct{}]struct{}
+}
+
+func NewEventHub() *EventHub {
+	return &EventHub{subs: make(map[chan struct{}]struct{})}
+}
+
+func (h *EventHub) Subscribe() chan struct{} {
+	ch := make(chan struct{}, 1)
+	h.mu.Lock()
+	h.subs[ch] = struct{}{}
+	h.mu.Unlock()
+	return ch
+}
+
+func (h *EventHub) Unsubscribe(ch chan struct{}) {
+	h.mu.Lock()
+	delete(h.subs, ch)
+	h.mu.Unlock()
+}
+
+func (h *EventHub) Notify() {
+	h.mu.Lock()
+	for ch := range h.subs {
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	}
+	h.mu.Unlock()
+}

--- a/server/serve_tasks.go
+++ b/server/serve_tasks.go
@@ -199,6 +199,7 @@ func (s *ServerConfig) claimTask(c *gin.Context) {
 			c.String(http.StatusInternalServerError, MakeErrorString(errMsg))
 		} else {
 			// Everything is fine
+			s.TaskEvents.Notify()
 			c.JSON(http.StatusOK, t)
 		}
 	}
@@ -238,6 +239,7 @@ func (s *ServerConfig) markTaskAsRunning(c *gin.Context) {
 		return
 	}
 
+	s.TaskEvents.Notify()
 	c.JSON(http.StatusOK, "{}")
 }
 
@@ -268,6 +270,7 @@ func (s *ServerConfig) cancelTask(c *gin.Context) {
 			c.String(http.StatusInternalServerError, MakeErrorString(err.Error()))
 			return
 		} else {
+			s.TaskEvents.Notify()
 			c.String(http.StatusOK, `{}`)
 			return
 		}
@@ -309,6 +312,7 @@ func (s *ServerConfig) markTaskAsFinished(c *gin.Context) {
 		return
 	}
 
+	s.TaskEvents.Notify()
 	c.JSON(http.StatusOK, "{}")
 }
 
@@ -469,6 +473,7 @@ func (s *ServerConfig) postTask(c *gin.Context) {
 		return
 	}
 
+	s.TaskEvents.Notify()
 	c.JSON(http.StatusCreated, t)
 }
 
@@ -501,6 +506,7 @@ func (s *ServerConfig) removeTask(c *gin.Context) {
 		return
 	}
 
+	s.TaskEvents.Notify()
 	c.String(http.StatusOK, fmt.Sprintf(`{"id": "%s"}`, taskId.Hex()))
 }
 

--- a/server/serve_workers.go
+++ b/server/serve_workers.go
@@ -100,6 +100,7 @@ func (s *ServerConfig) stopWorker(c *gin.Context) {
 		return
 	}
 
+	s.WorkerEvents.Notify()
 	c.String(http.StatusOK, `{}`)
 }
 
@@ -145,6 +146,7 @@ func (s *ServerConfig) deleteWorker(c *gin.Context) {
 		c.String(http.StatusInternalServerError, MakeErrorString(err.Error()))
 		return
 	}
+	s.WorkerEvents.Notify()
 	c.String(http.StatusOK, fmt.Sprintf(`{"id": "%s"}`, workerId.Hex()))
 }
 
@@ -186,6 +188,7 @@ func (s *ServerConfig) launchWorker(c *gin.Context, w *worker.WorkerConf) {
 	for {
 		w, _ := s.DB.GetWorker(w.Id)
 		if w.Pid != 0 {
+			s.WorkerEvents.Notify()
 			c.JSON(http.StatusOK, w)
 			return
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -57,9 +57,18 @@ type ServerConfig struct {
 	ResultsPath    string
 	Port           int
 	TimeMultiplier float64
+	TaskEvents     *EventHub
+	WorkerEvents   *EventHub
 }
 
 func (s *ServerConfig) GetRouter() *gin.Engine {
+	if s.TaskEvents == nil {
+		s.TaskEvents = NewEventHub()
+	}
+	if s.WorkerEvents == nil {
+		s.WorkerEvents = NewEventHub()
+	}
+
 	// https://godoc.org/github.com/rs/cors
 	c := cors.New(cors.Options{
 		AllowedOrigins:     []string{"*"},
@@ -108,6 +117,8 @@ func (s *ServerConfig) GetRouter() *gin.Engine {
 	r.GET("/ui/partials/custom-env-row", s.uiNextCustomEnvRowPartial)
 	r.GET("/ui/partials/new-worker", s.uiNextNewWorkerPartial)
 	r.GET("/ui/partials/blank", s.uiNextBlankPartial)
+	r.GET("/ui/sse/tasks", s.sseTaskEvents)
+	r.GET("/ui/sse/workers", s.sseWorkerEvents)
 
 	// Redirect to ui
 	r.GET("/", func(c *gin.Context) {

--- a/server/ui_next.go
+++ b/server/ui_next.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"fmt"
 	"html/template"
+	"io"
 	"io/fs"
 	"net/http"
 	"sort"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/manucorporat/sse"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cast"
 	"github.com/spf13/viper"
@@ -267,6 +269,7 @@ func (s *ServerConfig) uiNextSubmitWorker(c *gin.Context) {
 		}
 		time.Sleep(time.Duration(250*s.TimeMultiplier) * time.Millisecond)
 	}
+	s.WorkerEvents.Notify()
 	s.uiNextWorkersRowsPartial(c)
 }
 
@@ -469,6 +472,7 @@ func (s *ServerConfig) uiNextSubmitTask(c *gin.Context) {
 		c.String(http.StatusInternalServerError, err.Error())
 		return
 	}
+	s.TaskEvents.Notify()
 	s.uiNextTasksRowsPartial(c)
 }
 
@@ -478,4 +482,42 @@ func (s *ServerConfig) renderUINext(c *gin.Context, t *template.Template, data g
 	if err := t.ExecuteTemplate(c.Writer, "layout", data); err != nil {
 		log.WithField("err", err).Warn("ui-next: render page")
 	}
+}
+
+func (s *ServerConfig) sseStream(c *gin.Context, hub *EventHub, eventName string) {
+	ch := hub.Subscribe()
+	defer hub.Unsubscribe(ch)
+
+	seq := 0
+	send := func(w io.Writer) {
+		c.Writer.Header()["Content-Type"] = []string{"text/event-stream"}
+		sse.Encode(c.Writer, sse.Event{
+			Event: eventName,
+			Data:  "refresh",
+		})
+		seq++
+	}
+
+	// Send an initial event so the client catches up immediately.
+	c.Stream(func(w io.Writer) bool {
+		if seq == 0 {
+			send(w)
+			return true
+		}
+		select {
+		case <-ch:
+			send(w)
+		case <-time.After(30 * time.Second):
+			fmt.Fprintf(w, ": keepalive\n\n")
+		}
+		return true
+	})
+}
+
+func (s *ServerConfig) sseTaskEvents(c *gin.Context) {
+	s.sseStream(c, s.TaskEvents, "tasks-changed")
+}
+
+func (s *ServerConfig) sseWorkerEvents(c *gin.Context) {
+	s.sseStream(c, s.WorkerEvents, "workers-changed")
 }

--- a/server/ui_next/templates/tasks.html
+++ b/server/ui_next/templates/tasks.html
@@ -69,7 +69,7 @@
         </form>
     </details>
 
-    <table>
+    <table hx-ext="sse" sse-connect="/ui/sse/tasks">
         <thead>
             <tr>
                 <th>#</th>
@@ -85,7 +85,7 @@
         </thead>
         <tbody id="tasks-rows"
                hx-get="/ui/partials/tasks-rows"
-               hx-trigger="every 2s"
+               hx-trigger="sse:tasks-changed"
                hx-include="#task-filter"
                hx-target="this"
                hx-swap="innerHTML">

--- a/server/ui_next/templates/workers.html
+++ b/server/ui_next/templates/workers.html
@@ -16,7 +16,7 @@
         </button>
     </div>
     <div id="new-worker-form"></div>
-    <table>
+    <table hx-ext="sse" sse-connect="/ui/sse/workers">
         <thead>
             <tr>
                 <th>#</th>
@@ -31,7 +31,7 @@
         </thead>
         <tbody id="workers-rows"
                hx-get="/ui/partials/workers-rows"
-               hx-trigger="every 2s"
+               hx-trigger="sse:workers-changed"
                hx-target="this"
                hx-swap="innerHTML">
             {{template "workers-rows" .}}

--- a/tests/e2e/specs/journeys.spec.ts
+++ b/tests/e2e/specs/journeys.spec.ts
@@ -240,11 +240,11 @@ test.describe('Workers view', () => {
   });
 });
 
-// Auto-refresh — tasks/workers tbody polls every 2s, so a row submitted via
-// the API while the page is open should appear WITHOUT clicking Refresh.
+// SSE push — tasks/workers tables connect to SSE endpoints. A mutation
+// (e.g. API-submitted task) fires an event that triggers an htmx re-fetch.
 // ---------------------------------------------------------------------------
 
-test.describe('Auto-refresh', () => {
+test.describe('SSE push', () => {
   test.skip(skipBrowser, 'SKIP_BROWSER_TESTS=1');
 
   test.beforeEach(async ({ request }) => {
@@ -254,29 +254,32 @@ test.describe('Auto-refresh', () => {
     await purgeTasks(request);
   });
 
-  test('tasks page picks up an API-submitted task within the poll window', async ({
+  test('tasks page picks up an API-submitted task via SSE', async ({
     page,
     request,
   }) => {
     await page.goto('/ui/');
-    // Confirm the tbody has the polling attributes wired up.
+    const table = page.locator('table[sse-connect="/ui/sse/tasks"]');
+    await expect(table).toBeVisible();
     const tbody = page.locator('#tasks-rows');
-    await expect(tbody).toHaveAttribute('hx-trigger', 'every 2s');
+    await expect(tbody).toHaveAttribute('hx-trigger', 'sse:tasks-changed');
 
     const taskId = await createTask(request, 'echo_task');
     const idPrefix = taskId.slice(0, 8);
 
-    // Default polling cadence is 2s; allow up to 5s for the swap to land.
+    // SSE push should deliver the update within a few seconds.
     await expect(page.getByText(idPrefix, { exact: false })).toBeVisible({
       timeout: 5000,
     });
   });
 
-  test('workers tbody is wired for polling', async ({ page }) => {
+  test('workers table is wired for SSE push', async ({ page }) => {
     await page.goto('/ui/');
     await page.getByRole('link', { name: 'Workers' }).click();
+    const table = page.locator('table[sse-connect="/ui/sse/workers"]');
+    await expect(table).toBeVisible();
     const tbody = page.locator('#workers-rows');
-    await expect(tbody).toHaveAttribute('hx-trigger', 'every 2s');
+    await expect(tbody).toHaveAttribute('hx-trigger', 'sse:workers-changed');
     await expect(tbody).toHaveAttribute('hx-get', '/ui/partials/workers-rows');
   });
 });


### PR DESCRIPTION
## Summary

- Replaces `hx-trigger="every 2s"` polling on tasks and workers list pages with SSE-based push
- New `EventHub` pub/sub (`server/event_hub.go`) — mutation handlers call `Notify()`, SSE endpoints fan out to connected browsers
- SSE endpoints at `/ui/sse/tasks` and `/ui/sse/workers` send named events; HTMX `sse-connect` + `hx-trigger="sse:tasks-changed"` triggers the partial re-fetch only when data actually changes
- Cleans up completed NextUp.md items (branch protection, SSE list push, UI modernization)

## Design

The `EventHub` is intentionally minimal: buffered(1) channels per subscriber with non-blocking send means rapid mutations coalesce into a single event. SSE endpoints send an initial event on connect for catch-up, plus 30s keepalive pings.

Notifications are wired to state-changing mutations only — not worker heartbeats or progress updates (neither is visible in the list tables).

## Test plan

- [x] `make docker-test` — Go unit tests pass
- [x] `make docker-test-smoke` — smoke test passes
- [x] `make docker-test-browser` — all 22 Playwright tests pass (updated auto-refresh tests to assert SSE attributes)
- [ ] Manual: open tasks page, submit a task via API, confirm row appears without clicking Refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)