### PR TITLE
Add tag-triggered release workflow and install scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build toolchain image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          tags: blanket-dev:latest
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Cross-compile
+        run: make docker-build
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            blanket-linux-amd64
+            blanket-darwin-amd64
+            blanket-windows-amd64.exe

--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 Blanket is a RESTy wrapper for long running tasks.
 
+## Installation
+
+Download a pre-built binary from [GitHub Releases](https://github.com/turtlemonvh/blanket/releases), or use one of the one-liner installers below.
+
+**Linux / macOS:**
+
+```bash
+curl -sSfL https://raw.githubusercontent.com/turtlemonvh/blanket/master/scripts/install.sh | bash
+```
+
+**Windows (PowerShell):**
+
+```powershell
+irm https://raw.githubusercontent.com/turtlemonvh/blanket/master/scripts/install.ps1 | iex
+```
+
+Both scripts download the latest release to the current directory. Set
+`INSTALL_DIR` to install elsewhere (e.g. `INSTALL_DIR=/usr/local/bin`
+on Linux/macOS, `$env:INSTALL_DIR = "C:\Tools"` on Windows). Pin a
+specific version with `VERSION=v0.1.0`.
+
 ## Development setup
 
 Two options — pick one.

--- a/docs/NextUp.md
+++ b/docs/NextUp.md
@@ -48,14 +48,6 @@ effort than a normal test add.
 
 ## Build & CI
 
-- **Tagged-release automation in CI** — `.github/workflows/ci.yml` already
-  runs Go tests, smoke, Playwright, and cross-compile (the cross-compile
-  job runs on `push: master` only). Next step is a tag-triggered workflow
-  (`on: push: tags: ['v*']`) that runs `make docker-build` and attaches
-  the three binaries to a GitHub Release via
-  `softprops/action-gh-release@v2`. "Single binary that drops on any host"
-  is a load-bearing promise of the project — release tags should publish
-  it automatically.
 - **GHCR push of `blanket-dev:latest`** — currently every CI run rebuilds
   the toolchain image from scratch (GHA layer cache helps, but full cache
   misses cost ~5m). Pushing the image to `ghcr.io/turtlemonvh/blanket-dev`

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,44 @@
+# Install blanket — downloads the latest (or pinned) release binary for Windows.
+#
+# Usage:
+#   irm https://raw.githubusercontent.com/turtlemonvh/blanket/master/scripts/install.ps1 | iex
+#
+# Environment variables:
+#   VERSION      — tag to install (default: latest release, e.g. v0.1.0)
+#   INSTALL_DIR  — directory to place the binary (default: current directory)
+
+$ErrorActionPreference = "Stop"
+$Repo = "turtlemonvh/blanket"
+$Binary = "blanket-windows-amd64.exe"
+
+# Determine version
+if (-not $env:VERSION) {
+    $release = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest"
+    $Version = $release.tag_name
+    if (-not $Version) {
+        Write-Error "Could not determine latest release. Set `$env:VERSION explicitly."
+        exit 1
+    }
+} else {
+    $Version = $env:VERSION
+}
+
+$InstallDir = if ($env:INSTALL_DIR) { $env:INSTALL_DIR } else { "." }
+$Url = "https://github.com/$Repo/releases/download/$Version/$Binary"
+$OutFile = Join-Path $InstallDir "blanket.exe"
+
+Write-Host "Installing blanket $Version (windows/amd64) to $OutFile ..."
+
+if (-not (Test-Path $InstallDir)) {
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+}
+
+try {
+    Invoke-WebRequest -Uri $Url -OutFile $OutFile -UseBasicParsing
+} catch {
+    Remove-Item -Path $OutFile -ErrorAction SilentlyContinue
+    Write-Error "Download failed. Check that release $Version exists: https://github.com/$Repo/releases"
+    exit 1
+}
+
+Write-Host "Done. Run '$OutFile --help' to get started."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+set -e
+
+# Install blanket — downloads the latest (or pinned) release binary for
+# Linux or macOS.
+#
+# Usage:
+#   curl -sSfL https://raw.githubusercontent.com/turtlemonvh/blanket/master/scripts/install.sh | bash
+#
+# Environment variables:
+#   VERSION      — tag to install (default: latest release, e.g. v0.1.0)
+#   INSTALL_DIR  — directory to place the binary (default: current directory)
+
+REPO="turtlemonvh/blanket"
+
+# Detect OS
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$OS" in
+  linux)  BINARY="blanket-linux-amd64" ;;
+  darwin) BINARY="blanket-darwin-amd64" ;;
+  *)
+    echo "Error: unsupported OS '$OS'. Use Linux or macOS, or download manually from"
+    echo "  https://github.com/$REPO/releases"
+    exit 1
+    ;;
+esac
+
+# Detect arch
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64|amd64) ;; # supported
+  *)
+    echo "Error: unsupported architecture '$ARCH'. Only amd64/x86_64 binaries are available."
+    echo "  https://github.com/$REPO/releases"
+    exit 1
+    ;;
+esac
+
+# Determine version
+if [ -z "$VERSION" ]; then
+  VERSION=$(curl -sSf "https://api.github.com/repos/$REPO/releases/latest" \
+    | grep '"tag_name"' | head -1 | cut -d'"' -f4)
+  if [ -z "$VERSION" ]; then
+    echo "Error: could not determine latest release. Set VERSION explicitly:"
+    echo "  VERSION=v0.1.0 curl -sSfL ... | bash"
+    exit 1
+  fi
+fi
+
+INSTALL_DIR="${INSTALL_DIR:-.}"
+URL="https://github.com/$REPO/releases/download/$VERSION/$BINARY"
+
+echo "Installing blanket $VERSION ($OS/amd64) to $INSTALL_DIR/blanket ..."
+
+mkdir -p "$INSTALL_DIR"
+
+HTTP_CODE=$(curl -sSL -w "%{http_code}" -o "$INSTALL_DIR/blanket" "$URL")
+if [ "$HTTP_CODE" -ne 200 ]; then
+  rm -f "$INSTALL_DIR/blanket"
+  echo "Error: download failed (HTTP $HTTP_CODE). Check that release $VERSION exists:"
+  echo "  https://github.com/$REPO/releases"
+  exit 1
+fi
+
+chmod +x "$INSTALL_DIR/blanket"
+
+echo "Done. Run '$INSTALL_DIR/blanket --help' to get started."


### PR DESCRIPTION
## Summary

- New `.github/workflows/release.yml` — triggered on `v*` tags, cross-compiles linux/darwin/windows amd64, attaches binaries to a GitHub Release with auto-generated release notes
- New `scripts/install.sh` — `curl | bash` installer for Linux/macOS
- New `scripts/install.ps1` — `irm | iex` installer for Windows
- README "Installation" section with one-liner install commands
- NextUp.md tagged-release item removed

## Test plan

- [x] Go build + gofmt clean
- [ ] CI passes on this PR (no Go code changes — just YAML, shell, PowerShell, markdown)
- [ ] After merge: tag `v0.1.0`, confirm release workflow creates a GitHub Release with 3 binaries
- [ ] Test install script: `curl -sSfL .../install.sh | bash` from a clean dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)