### PR TITLE
Improve install experience, version command, and docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Cross-compile
-        run: make docker-build
+        run: make docker-build VERSION=${{ github.ref_name }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,84 +39,28 @@ binary invoked with different subcommands.
 ## Build & test
 
 Docker is the reproducible path — same image locally and in CI.
+See [CONTRIBUTORS.md](CONTRIBUTORS.md) for the full target list, CI
+details, and release process.
 
 ```
 make docker-test           # Go unit tests
 make docker-test-smoke     # built binary end-to-end (scripts/smoke.sh)
 make docker-test-browser   # Playwright suite
-make docker-shell          # interactive container for ad-hoc work
 make docker-build          # cross-compile linux/darwin/windows
-make docker-clean          # drop persisted Go + npm cache volumes
 ```
 
-Native targets (`make test`, `make linux`, etc.) work if you ran
-`make setup` first; the docker targets are the authoritative CI path.
-
-**After bumping `go.sum` or `tests/e2e/package-lock.json`:** run
-`make docker-clean` so the next `make docker-*` rebuilds the named
-volumes from the freshly built image layer.
-
-## CI
-
-`.github/workflows/ci.yml` runs on PRs and master pushes.
-
-- `test` (required check): builds the image, then runs `docker-check-fmt`,
-  `docker-test`, `docker-test-smoke`, `docker-test-browser` in sequence.
-  Uploads Playwright HTML report as an artifact on failure.
-- `cross-compile` (master pushes only): `make docker-build` — catches
-  platform-only breakage without spending minutes on every PR.
-
-Branch protection on master requires `test` green and up-to-date with
-master (`strict: true`). Admins can bypass; the user's normal workflow is
-still PR → merge, not direct push.
-
-**Test adds must keep all three surfaces green.** The suites overlap
-intentionally: unit tests hit handlers directly, smoke exercises the
-built binary over real HTTP, Playwright drives the UI.
+Test adds must keep all three surfaces green (unit, smoke, Playwright).
 
 ## Code conventions
 
-- **Run `go fmt` before committing.** `make check-fmt` fails CI if any
-  file isn't gofmt-clean.
+See [CONTRIBUTORS.md](CONTRIBUTORS.md) for the full list. Key points
+for AI sessions:
+
+- **Run `go fmt` before committing.** `make check-fmt` fails CI.
 - **Platform-specific code uses `//go:build` tags, not runtime switches.**
-  See `worker/daemon_unix.go` / `worker/daemon_windows.go` for the
-  pattern: one file per platform, tagged at the top, implementing a
-  shared function signature. Do NOT import unix-only syscall fields in a
-  file compiled on all platforms.
-- **Logging is mixed** (`log.Printf` stdlib + logrus). New code should
-  prefer `log "github.com/sirupsen/logrus"` to match the dominant style.
-  Unifying is a tracked phase candidate in NextUp.
-- **IDs are `lib/objectid.ObjectId`** — a 24-char hex MongoDB-style id.
-  Do not hand-roll UUIDs. The tracked refactor to `TaskID`/`WorkerID`
-  newtypes is intentionally deferred (breaks wire format + on-disk state).
-- **Error status codes on `server/` handlers are inconsistent** — there's
-  an active NextUp item to normalize missing-id → 404 via
-  `lib/database.ItemNotFoundError`. Don't add new handlers that return
-  500 for missing-resource cases; use the 404 pattern.
-
-## Task type schema
-
-TOML files under any directory in `tasks.typesPaths` (config). Loader
-is `tasks/task_types.go`; the name is the filename stem.
-
-```
-tags = ["bash", "unix"]   # worker-capability match; worker must advertise all
-timeout = 300             # seconds; default 3600
-command = "..."           # Go text/template, .ExecEnv is the env map
-executor = "bash"         # declared but UNUSED — everything shells via bash -c
-
-  [[environment.required]]
-  name = "DEFAULT_COMMAND"
-  description = "..."
-
-  [[environment.default]]
-  name = "NAME"
-  value = "world"
-```
-
-`{{.VAR}}` substitutes at submit time AND `$VAR` works at exec time
-(blanket sets them both). See `examples/types/*.toml` for copy-paste
-starters; `testdata/types/echo_task.toml` stays minimal for smoke.
+- **Logging:** prefer `log "github.com/sirupsen/logrus"`.
+- **IDs are `lib/objectid.ObjectId`** — don't hand-roll UUIDs.
+- **Error status codes:** missing-id → 404 via `ItemNotFoundError`.
 
 ## Commit style
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,163 @@
+# Contributing to Blanket
+
+## Development Setup
+
+Two options — pick one.
+
+**Native (Ubuntu / WSL2)** — installs Go, Node, and Playwright locally
+(uses `sudo` for apt + `/usr/local/go`). See `scripts/setup.sh`:
+
+```bash
+make setup
+```
+
+**Docker** — reproducible toolchain image; the same image CI will run. No
+local Go or Node install needed:
+
+```bash
+make docker-test           # Go unit tests in the container
+make docker-test-browser   # Playwright suite
+make docker-test-smoke     # binary smoke test
+make docker-shell          # interactive shell, source mounted at /src
+```
+
+See `Dockerfile` for what the image carries.
+
+## Build & Test
+
+### Docker targets (authoritative CI path)
+
+```
+make docker-test           # Go unit tests
+make docker-test-smoke     # built binary end-to-end (scripts/smoke.sh)
+make docker-test-browser   # Playwright suite
+make docker-shell          # interactive container for ad-hoc work
+make docker-build          # cross-compile linux/darwin/windows
+make docker-clean          # drop persisted Go + npm cache volumes
+```
+
+### Native targets
+
+```
+make linux                 # build for Linux
+make darwin                # build for macOS
+make windows               # build for Windows
+make test                  # run Go unit tests
+make test-smoke            # run smoke tests
+make test-browser          # run Playwright tests
+make fmt                   # gofmt all Go files
+make check-fmt             # fail if any Go file isn't gofmt-clean
+```
+
+After bumping `go.sum` or `tests/e2e/package-lock.json`, run
+`make docker-clean` so the next `make docker-*` rebuilds the named
+volumes from the freshly built image layer.
+
+## CI
+
+`.github/workflows/ci.yml` runs on PRs and master pushes.
+
+- **`test`** (required check): builds the image, then runs
+  `docker-check-fmt`, `docker-test`, `docker-test-smoke`,
+  `docker-test-browser` in sequence. Uploads Playwright HTML report
+  as an artifact on failure.
+- **`cross-compile`** (master pushes only): `make docker-build` —
+  catches platform-only breakage without spending minutes on every PR.
+
+Branch protection on master requires `test` green and up-to-date with
+master (`strict: true`). Admins can bypass; the normal workflow is
+PR → merge, not direct push.
+
+Test adds must keep all three surfaces green. The suites overlap
+intentionally: unit tests hit handlers directly, smoke exercises the
+built binary over real HTTP, Playwright drives the UI.
+
+## Release Process
+
+1. Merge changes to `master` and ensure CI passes.
+2. Tag the commit: `git tag v0.2.0 && git push origin v0.2.0`
+3. The `.github/workflows/release.yml` workflow triggers on `v*` tags:
+   - Builds the Docker toolchain image
+   - Cross-compiles via `make docker-build VERSION=<tag>`
+   - Creates a GitHub Release with auto-generated notes
+   - Attaches binaries: `blanket-linux-amd64`, `blanket-darwin-amd64`,
+     `blanket-windows-amd64.exe`
+
+The `VERSION` make variable is passed through as an ldflags `-X` value,
+along with `BUILD_DATE` (local time at minute precision). Tagged builds
+produce version output like `blanket v0.2.0 (built 2026-05-01 11:14 PM EDT)`.
+
+Install scripts (`scripts/install.sh`, `scripts/install.ps1`) fetch the
+latest release from the GitHub API.
+
+## Code Conventions
+
+- **Run `go fmt` before committing.** `make check-fmt` fails CI if any
+  file isn't gofmt-clean.
+- **Platform-specific code uses `//go:build` tags, not runtime switches.**
+  See `worker/daemon_unix.go` / `worker/daemon_windows.go` for the
+  pattern: one file per platform, tagged at the top, implementing a
+  shared function signature. Do NOT import unix-only syscall fields in a
+  file compiled on all platforms.
+- **Logging is mixed** (`log.Printf` stdlib + logrus). New code should
+  prefer `log "github.com/sirupsen/logrus"` to match the dominant style.
+- **IDs are `lib/objectid.ObjectId`** — a 24-char hex MongoDB-style id.
+  Do not hand-roll UUIDs.
+- **Error status codes on `server/` handlers** — normalize missing-id
+  errors to 404 via `lib/database.ItemNotFoundError`. Don't add new
+  handlers that return 500 for missing-resource cases.
+
+## Commit Style
+
+`[AI] <imperative short summary>` for AI-authored commits, followed by
+a body explaining the *why*. Example:
+
+```
+[AI] fix windows cross-compile: split daemon attrs by platform
+
+cmd.SysProcAttr.Setpgid is unix-only — windows' syscall.SysProcAttr
+has no Setpgid field, ...
+```
+
+Match the repo's existing subject-line style; check `git log --oneline`
+if in doubt.
+
+## Single-binary Architecture
+
+`go build` produces a single static binary with the web UI baked in.
+Templates, CSS, and vendored htmx live under `server/ui_next/` and are
+pulled into the binary via `//go:embed` (see `server/ui_next.go`). No
+separate asset deploy, no runtime filesystem lookups.
+
+To refresh the vendored htmx bundle:
+
+```bash
+curl -sSfL https://unpkg.com/htmx.org@1.9.12/dist/htmx.min.js \
+    -o server/ui_next/static/htmx.min.js
+curl -sSfL https://unpkg.com/htmx.org@1.9.12/dist/ext/sse.js \
+    -o server/ui_next/static/htmx-sse.js
+```
+
+## Task Type Schema
+
+TOML files under any directory in `tasks.typesPaths` (config). Loader
+is `tasks/task_types.go`; the name is the filename stem.
+
+```toml
+tags = ["bash", "unix"]   # worker-capability match; worker must advertise all
+timeout = 300             # seconds; default 3600
+command = "..."           # Go text/template, .ExecEnv is the env map
+executor = "bash"         # bash (default), cmd, powershell, or any -c executor
+
+  [[environment.required]]
+  name = "DEFAULT_COMMAND"
+  description = "..."
+
+  [[environment.default]]
+  name = "NAME"
+  value = "world"
+```
+
+`{{.VAR}}` substitutes at submit time AND `$VAR` works at exec time
+(blanket sets them both). See `examples/types/*.toml` for copy-paste
+starters; `testdata/types/echo_task.toml` stays minimal for smoke.

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,14 @@ GOARCH = amd64
 
 COMMIT=$(shell git rev-parse HEAD)
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+VERSION ?=
+BUILD_DATE = $(shell date +"%Y-%m-%d %-I:%M %p %Z")
 
 # Symlink into GOPATH
 GITHUB_USERNAME=turtlemonvh
 
 # Setup the -ldflags option for go build here, interpolate the variable values
-LDFLAGS = -ldflags "-X main.COMMIT=${COMMIT} -X main.BRANCH=${BRANCH}"
+LDFLAGS = -ldflags "-X main.COMMIT=${COMMIT} -X main.BRANCH=${BRANCH} -X 'main.VERSION=${VERSION}' -X 'main.BUILD_DATE=${BUILD_DATE}'"
 
 # Build the project
 all: clean test vet linux darwin windows
@@ -121,7 +123,7 @@ docker-test-smoke: docker-image
 	$(DOCKER_RUN) make linux test-smoke
 
 docker-build: docker-image
-	$(DOCKER_RUN) make linux darwin windows
+	$(DOCKER_RUN) make linux darwin windows VERSION=$(VERSION)
 
 # Interactive shell in the toolchain image for ad-hoc work.
 docker-shell: docker-image

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Blanket
 
-Blanket is a RESTy wrapper for long running tasks.
+Blanket is a RESTy wrapper for long running tasks. Define task types as
+TOML files, submit them via REST API or CLI, and let workers execute
+them — all from a single binary with a built-in web UI.
 
 ## Installation
 
@@ -18,196 +20,151 @@ curl -sSfL https://raw.githubusercontent.com/turtlemonvh/blanket/master/scripts/
 irm https://raw.githubusercontent.com/turtlemonvh/blanket/master/scripts/install.ps1 | iex
 ```
 
-Both scripts download the latest release to the current directory. Set
-`INSTALL_DIR` to install elsewhere (e.g. `INSTALL_DIR=/usr/local/bin`
-on Linux/macOS, `$env:INSTALL_DIR = "C:\Tools"` on Windows). Pin a
-specific version with `VERSION=v0.1.0`.
+The installers download the binary, create config/data directories
+(XDG-compliant on Linux/macOS, `%LOCALAPPDATA%\blanket` on Windows),
+write a default config file, and fetch the example task types. Set
+`INSTALL_DIR` to override the binary location, or `VERSION=v0.1.0`
+to pin a release.
 
-## Development setup
-
-Two options — pick one.
-
-**Native (Ubuntu / WSL2)** — installs Go, Node, and Playwright locally
-(uses `sudo` for apt + `/usr/local/go`). See `scripts/setup.sh`:
-
-```bash
-make setup
-```
-
-**Docker** — reproducible toolchain image; the same image CI will run. No
-local Go or Node install needed:
-
-```bash
-make docker-test           # Go unit tests in the container
-make docker-test-browser   # Playwright suite
-make docker-test-smoke     # binary smoke test
-make docker-shell          # interactive shell, source mounted at /src
-```
-
-See `Dockerfile` for what the image carries.
+| | Binary | Config | Data |
+|---|---|---|---|
+| Linux/macOS | `~/.local/bin/blanket` | `~/.config/blanket/` | `~/.local/share/blanket/` |
+| Windows | `%LOCALAPPDATA%\blanket\bin\blanket.exe` | `%LOCALAPPDATA%\blanket\` | `%LOCALAPPDATA%\blanket\` |
 
 ## Quick Start
 
 ```bash
-# Build the binary. `make linux` → ./blanket-linux-amd64,
-# `make darwin` → ./blanket-darwin-amd64, `make windows` → .exe.
-make linux
-
-# Copy the shipped example task types so there's something to exercise.
-# Drop your own TOML files in this directory (or any directory listed in
-# `tasks.typesPaths`) as you build up your own types.
-cp -r examples/types ./types
-
-# Create a config file
-cat > blanket.json <<'EOF'
-{
-  "port": 8773,
-  "tasks": {
-    "typesPaths": ["./types"],
-    "resultsPath": "results"
-  },
-  "logLevel": "debug"
-}
-EOF
-
-# Run server
-./blanket-linux-amd64
+# Start the server (uses ~/.config/blanket/config.json by default)
+blanket
 ```
 
-Once the server is running, you can view the web UI at [http://localhost:8773/](http://localhost:8773/).  You can also interact with blanket via curl and the command line.  For example, you can list tasks
+Open the web UI at [http://localhost:8773/](http://localhost:8773/).
 
 ```bash
-curl -s -X GET localhost:8773/task/ | jq .
+# List tasks
+blanket ps
+
+# Submit a task
+curl -s -X POST localhost:8773/task/ -d '{"type": "echo_task"}'
 # OR
-./blanket-linux-amd64 ps
+blanket submit -t echo_task
+
+# Run a worker with specific capabilities
+blanket worker -t bash,unix
 ```
 
-Submit a task of the shipped `echo_task` type (the minimal one — just
-writes a string to stdout):
+## Usage
+
+### Submitting tasks
+
+The `echo_task` example writes a fixed string to stdout:
 
 ```bash
 curl -s -X POST localhost:8773/task/ \
     -d '{"type": "echo_task"}'
 ```
 
-The `bash_task` example takes a `DEFAULT_COMMAND` env var and runs it
-through bash — the generic escape hatch for ad-hoc commands:
+The `bash_task` example takes a `DEFAULT_COMMAND` env var and runs it:
 
 ```bash
 curl -s -X POST localhost:8773/task/ \
     -d '{"type": "bash_task", "environment": {"DEFAULT_COMMAND": "echo $(date)"}}'
-curl -X POST localhost:8773/task/ \
-    -d '{"type": "bash_task", "environment": {"DEFAULT_COMMAND": "cd ~ && ls -lah"}}'
 ```
 
-The `python_hello` example shells out to `python3` and has an optional
-`NAME` env var with a default:
+The `python_hello` example shells out to `python3`:
 
 ```bash
 curl -s -X POST localhost:8773/task/ \
     -d '{"type": "python_hello", "environment": {"NAME": "blanket"}}'
 ```
 
-See `examples/types/*.toml` for the schema; drop your own TOML files
-into `./types/` and submit them the same way.
-
-Add a task and upload some data files with it. Files will be placed at the root of the directory where the task runs.
-
-```bash
-# Send task as a form field named data with multiple files
-curl -X POST localhost:8773/task/ \
-    -F data='{"type": "echo_task", "environment": {"GREETING": "hi"}}' \
-    -F blanket.json=@blanket.json
-
-# Send task data as another file named "data"
-cat > data.json <<'EOF'
-{
-    "type": "echo_task",
-    "environment": {
-        "GREETING": "hi"
-    }
-}
-EOF
-curl -X POST localhost:8773/task/ -F data=@data.json -F blanket.json=@blanket.json
-```
-
-Add lots of tasks
-
-```bash
-while true; do
-    curl -X POST localhost:8773/task/ \
-        -F data=@data.json \
-        -F blanket.json=@blanket.json
-    echo "$(date)"
-    sleep 5
-done
-```
-
-There is also limited functionality for sending tasks via the command line.
+Submit via CLI (useful for scripting):
 
 ```
-# Send in a single task
-$ ./blanket-linux-amd64 submit -t echo_task -e '{"GREETING": "hi"}'
+$ blanket submit -t echo_task -e '{"GREETING": "hi"}'
 echo_task 69ded2acce42aa8a11ac9ddc [1744748400]
 
-# Send in a single task, printing only the id of the task once it is submitted
-$ ./blanket-linux-amd64 submit -t echo_task -e '{"GREETING": "hi"}' -q
+$ blanket submit -t echo_task -e '{"GREETING": "hi"}' -q
 69ded2adce42aa8a11ac9de0
 ```
 
-Delete a task
+### File uploads
+
+Attach files to a task — they're placed in the task's working directory:
 
 ```bash
-curl -s -X DELETE localhost:8773/task/69ded2acce42aa8a11ac9ddc | jq .
-# OR
-./blanket-linux-amd64 ps -q | tail -n1 | xargs ./blanket-linux-amd64 rm
+curl -X POST localhost:8773/task/ \
+    -F data='{"type": "echo_task", "environment": {"GREETING": "hi"}}' \
+    -F blanket.json=@blanket.json
+```
+
+### Managing tasks
+
+```bash
+# Delete a task
+curl -s -X DELETE localhost:8773/task/<task-id> | jq .
+blanket rm <task-id>
 
 # Remove all tasks
-./blanket-linux-amd64 ps -q | xargs -I {} ./blanket-linux-amd64 rm {}
+blanket ps -q | xargs -I {} blanket rm {}
 ```
 
-Run worker with certain capabilities
+### Validating task types
+
+Check that all configured task types are runnable (executor exists on
+PATH, command is non-empty):
 
 ```bash
-# You can also launch from the web UI or via an api call
-./blanket-linux-amd64 worker -t unix,bash,python
+blanket task-validate
 ```
 
-## Single-binary distribution
+### Writing task types
 
-`go build` produces a single static binary with the web UI baked in.
-Templates, CSS, and vendored htmx live under `server/ui_next/` and are
-pulled into the binary via `//go:embed` (see `server/ui_next.go`). No
-separate asset deploy, no runtime filesystem lookups — drop the binary
-on a host and run it.
+Task types are TOML files. Drop them in any directory listed in
+`tasks.typesPaths` in your config. The filename stem becomes the type
+name.
 
-To refresh the vendored htmx bundle:
+```toml
+tags = ["bash", "unix"]
+executor = "bash"
+command = "echo 'hello from blanket'"
+timeout = 300
 
-```bash
-curl -sSfL https://unpkg.com/htmx.org@1.9.12/dist/htmx.min.js \
-    -o server/ui_next/static/htmx.min.js
-curl -sSfL https://unpkg.com/htmx.org@1.9.12/dist/ext/sse.js \
-    -o server/ui_next/static/htmx-sse.js
+  [[environment.default]]
+  name = "NAME"
+  value = "world"
+
+  [[environment.required]]
+  name = "INPUT_FILE"
+  description = "Path to the input data"
 ```
 
-## Command line API
+Supported executors: `bash` (default), `cmd` (Windows), `powershell`,
+or any executable that accepts `-c <command>`.
 
-```bash
-$ ./blanket-linux-amd64 -h
-A fast and easy way to wrap applications and make them available via nice clean REST interfaces with built in UI, command line tools, and queuing, all in a single binary!
+See `examples/types/*.toml` for working examples.
+
+## Command Reference
+
+```
+$ blanket -h
+A fast and easy way to wrap applications and make them available via nice clean
+REST interfaces with built in UI, command line tools, and queuing, all in a
+single binary!
 
 Usage:
   blanket [flags]
   blanket [command]
 
 Available Commands:
-  completion  Generate the autocompletion script for the specified shell
-  help        Help about any command
-  ps          List active and queued tasks
-  rm          Remove tasks
-  submit      Submit a task to be executed.
-  version     Print the version number of blanket
-  worker      Run a worker with capabilities defined by tags
+  completion    Generate the autocompletion script for the specified shell
+  help          Help about any command
+  ps            List active and queued tasks
+  rm            Remove tasks
+  submit        Submit a task to be executed.
+  task-validate Validate that task types are runnable
+  version       Print the version number of blanket
+  worker        Run a worker with capabilities defined by tags
 
 Flags:
   -c, --config string     config file (default is blanket.yaml|json|toml)
@@ -218,47 +175,7 @@ Flags:
 Use "blanket [command] --help" for more information about a command.
 ```
 
-## Specs
+## Contributing
 
-See [the docs directory](https://github.com/turtlemonvh/blanket/tree/master/docs) for more detailed information about the design of blanket.
-
-### Origin
-
-Blanket was designed because of problems I saw on several projects in [GTRI's ELSYS branch](https://www.gtri.gatech.edu/elsys) where we wanted to be able to integrate a piece of software with a less than awesome API into another tool.  Whether that software was a long running simulation, a CAD renderer, or some other strange beast, we kept seeing people try to wrap HTTP servers around these utilities.  This seemed unnecessary and wasteful.
-
-The starting concept of blanket was simple: If we can wrap anything with a command line call (which is possible with tools like [sikuli](http://www.sikuli.org/)), and we could make it easy to expose any command line script as a web endpoint, then we can provide a nice consistent way to expose cool software with a possibly bad API to a larger class of users.
-
-The first draft of blanket was written in python and used celery for queuing. It worked fine, but was a bit heavy weight, and was hard for some Windows users to install. Go was chosen for the rewrite since
-
-* It compiles to a single binary, so deployment is easy
-* It cross compiles to many platforms, so getting it to behave on windows shouldn't be too painful
-
-This was my first major project in Go, and the code base is still recovering from some early "experiments".  It is still a bit rough around the edges, but I do use blanket almost every day at work to manage long running tasks that I'd like to keep a record of, like code deployments.  In this regard, it's a bit like a light-weight [jenkins](https://jenkins.io/).  I plan to continue working on blanket, and I expect it will become a major component of many of my future side projects.
-
-If you are interested in using blanket for a project and want to ask whether blanket may be a good match, you can either [submit a github issue with your question](https://github.com/turtlemonvh/blanket/issues) or find me on twitter [@turtlemonvh](https://twitter.com/turtlemonvh).
-
-### Design Goals
-
-> This is how we want it to work, not necessarily how it works now.
-
-* Speed is not a high priority at the moment. Instead, we favor 
-    * simplicity: API is easy to work with, and tasks are hard to lose
-    * pluggability: It is easy to change storage and queue backends while maintaining the same API.
-    * traceable: It's easy to understand what's going on.
-    * open: It's easy to get data in and out.
-    * low resourse usage: Like [xinetd](https://en.wikipedia.org/wiki/Xinetd), it can be present and usable without you thinking about it.
-* Blanket is designed for long running tasks, not high speed messaging. We assume
-    * Tasks will be running for a long time (several seconds or more).
-    * Contention between workers will be fairly low.
-* TOML files drive all configuration for tasks
-* The web UI is optional
-    * Everything can be done without it, easily
-    * The main feature is a json/rest interface
-
-
-## Misc
-
-* Go modules for dependency management
-* `//go:embed` for static files (see `server/ui_next.go`)
-* Server-rendered Go templates + [htmx](https://htmx.org/) for the web UI
-
+See [CONTRIBUTORS.md](CONTRIBUTORS.md) for development setup, build
+instructions, CI details, and code conventions.

--- a/command/root.go
+++ b/command/root.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"os"
+	"path/filepath"
+	"runtime"
 )
 
 var blanketCmdV *cobra.Command
@@ -22,11 +24,11 @@ var (
 	Version  string
 )
 
-func Run(VERSION string, BRANCH string, COMMIT string) {
+func Run(VERSION string, BRANCH string, COMMIT string, BUILD_DATE string) {
 	if VERSION != "" {
-		Version = fmt.Sprintf("Blanket v%s", VERSION)
+		Version = fmt.Sprintf("blanket %s (built %s)", VERSION, BUILD_DATE)
 	} else {
-		Version = fmt.Sprintf("Blanket v? (branch=%s, commit=%s)", BRANCH, COMMIT)
+		Version = fmt.Sprintf("blanket (dev) branch=%s commit=%s (built %s)", BRANCH, COMMIT, BUILD_DATE)
 	}
 	RootCmd.Execute()
 }
@@ -37,6 +39,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&LogLevel, "logLevel", "info", "the logging level to use")
 	RootCmd.PersistentFlags().StringVarP(&CfgFile, "config", "c", "", "config file (default is blanket.yaml|json|toml)")
 	RootCmd.AddCommand(versionCmd)
+	RootCmd.AddCommand(taskValidateCmd)
 	blanketCmdV = RootCmd
 
 	// FIXME: Add support for multiple outputs and handling log levels via command line or env variable
@@ -59,6 +62,21 @@ func InitializeConfig() {
 	viper.SetDefault("timeMultiplier", "1.0")
 
 	viper.SetConfigName("blanket")
+	if runtime.GOOS == "windows" {
+		if localAppData := os.Getenv("LOCALAPPDATA"); localAppData != "" {
+			viper.AddConfigPath(filepath.Join(localAppData, "blanket"))
+		}
+	} else {
+		configHome := os.Getenv("XDG_CONFIG_HOME")
+		if configHome == "" {
+			if home, err := os.UserHomeDir(); err == nil {
+				configHome = filepath.Join(home, ".config")
+			}
+		}
+		if configHome != "" {
+			viper.AddConfigPath(filepath.Join(configHome, "blanket"))
+		}
+	}
 	viper.AddConfigPath("/etc/blanket/")
 	viper.AddConfigPath("$HOME/.blanket")
 	viper.AddConfigPath(".")

--- a/command/task_validate.go
+++ b/command/task_validate.go
@@ -1,0 +1,74 @@
+package command
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"github.com/turtlemonvh/blanket/tasks"
+)
+
+var taskValidateCmd = &cobra.Command{
+	Use:   "task-validate [type-name]",
+	Short: "Validate that task types are runnable",
+	Long:  `Checks that each task type's executor is on $PATH and that the command field is non-empty.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		InitializeConfig()
+
+		tts, err := tasks.ReadTypes()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading task types: %s\n", err)
+			os.Exit(1)
+		}
+
+		if len(args) > 0 {
+			name := args[0]
+			found := false
+			for i := range tts {
+				if tts[i].GetName() == name {
+					tts = []tasks.TaskType{tts[i]}
+					found = true
+					break
+				}
+			}
+			if !found {
+				fmt.Fprintf(os.Stderr, "Task type %q not found\n", name)
+				os.Exit(1)
+			}
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+		fmt.Fprintln(w, "NAME\tEXECUTOR\tCOMMAND\tSTATUS")
+
+		anyFailed := false
+		for _, tt := range tts {
+			executor := tt.Config.GetString("executor")
+			if executor == "" {
+				executor = "bash"
+			}
+			command := tt.Config.GetString("command")
+
+			status := "ok"
+			if command == "" {
+				status = "missing command"
+				anyFailed = true
+			} else if _, err := exec.LookPath(executor); err != nil {
+				status = fmt.Sprintf("executor not found: %s", executor)
+				anyFailed = true
+			}
+
+			cmdDisplay := command
+			if len(cmdDisplay) > 40 {
+				cmdDisplay = cmdDisplay[:37] + "..."
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", tt.GetName(), executor, cmdDisplay, status)
+		}
+		w.Flush()
+
+		if anyFailed {
+			os.Exit(1)
+		}
+	},
+}

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,53 @@
+# Design & Origin
+
+## Origin
+
+Blanket was designed because of problems I saw on several projects in
+[GTRI's ELSYS branch](https://www.gtri.gatech.edu/elsys) where we
+wanted to be able to integrate a piece of software with a less than
+awesome API into another tool. Whether that software was a long running
+simulation, a CAD renderer, or some other strange beast, we kept seeing
+people try to wrap HTTP servers around these utilities. This seemed
+unnecessary and wasteful.
+
+The starting concept of blanket was simple: If we can wrap anything with
+a command line call (which is possible with tools like
+[sikuli](http://www.sikuli.org/)), and we could make it easy to expose
+any command line script as a web endpoint, then we can provide a nice
+consistent way to expose cool software with a possibly bad API to a
+larger class of users.
+
+The first draft of blanket was written in python and used celery for
+queuing. It worked fine, but was a bit heavy weight, and was hard for
+some Windows users to install. Go was chosen for the rewrite since:
+
+* It compiles to a single binary, so deployment is easy
+* It cross compiles to many platforms, so getting it to behave on
+  Windows shouldn't be too painful
+
+## Design Goals
+
+> This is how we want it to work, not necessarily how it works now.
+
+* Speed is not a high priority at the moment. Instead, we favor:
+    * **Simplicity** — API is easy to work with, and tasks are hard to lose
+    * **Pluggability** — easy to change storage and queue backends while maintaining the same API
+    * **Traceability** — easy to understand what's going on
+    * **Openness** — easy to get data in and out
+    * **Low resource usage** — like [xinetd](https://en.wikipedia.org/wiki/Xinetd), it can be present and usable without you thinking about it
+* Blanket is designed for long running tasks, not high speed messaging. We assume:
+    * Tasks will be running for a long time (several seconds or more)
+    * Contention between workers will be fairly low
+* TOML files drive all configuration for tasks
+* The web UI is optional — everything can be done without it, easily. The main feature is the JSON/REST interface.
+
+## Architecture
+
+* Go modules for dependency management
+* `//go:embed` for static files (see `server/ui_next.go`)
+* Server-rendered Go templates + [htmx](https://htmx.org/) for the web UI
+* BoltDB for storage; internal queue abstraction
+* Gin for HTTP routing
+* Single binary — server and worker are the same binary invoked with different subcommands
+
+See [the docs directory](https://github.com/turtlemonvh/blanket/tree/master/docs) for more detailed information.

--- a/examples/types/windows_echo.toml
+++ b/examples/types/windows_echo.toml
@@ -1,0 +1,8 @@
+# Windows-native task type — runs via cmd.exe, no bash/WSL needed.
+# Always runnable on Windows so there's at least one working example
+# out of the box.
+
+tags = ["windows"]
+executor = "cmd"
+command = "echo hello from blanket"
+timeout = 10

--- a/main.go
+++ b/main.go
@@ -5,11 +5,12 @@ import (
 )
 
 var (
-	COMMIT  string
-	BRANCH  string
-	VERSION string
+	COMMIT     string
+	BRANCH     string
+	VERSION    string
+	BUILD_DATE string
 )
 
 func main() {
-	command.Run(VERSION, BRANCH, COMMIT)
+	command.Run(VERSION, BRANCH, COMMIT, BUILD_DATE)
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,15 +1,19 @@
-# Install blanket — downloads the latest (or pinned) release binary for Windows.
+# Install blanket — downloads the latest (or pinned) release binary for Windows,
+# creates config/data directories under %LOCALAPPDATA%, and downloads example
+# task types.
 #
 # Usage:
 #   irm https://raw.githubusercontent.com/turtlemonvh/blanket/master/scripts/install.ps1 | iex
 #
 # Environment variables:
 #   VERSION      — tag to install (default: latest release, e.g. v0.1.0)
-#   INSTALL_DIR  — directory to place the binary (default: current directory)
+#   INSTALL_DIR  — directory to place the binary (default: %LOCALAPPDATA%\blanket\bin)
 
 $ErrorActionPreference = "Stop"
 $Repo = "turtlemonvh/blanket"
+$RawBase = "https://raw.githubusercontent.com/$Repo/master"
 $Binary = "blanket-windows-amd64.exe"
+$ExampleTypes = @("echo_task.toml", "bash_task.toml", "python_hello.toml", "windows_echo.toml")
 
 # Determine version
 if (-not $env:VERSION) {
@@ -23,14 +27,27 @@ if (-not $env:VERSION) {
     $Version = $env:VERSION
 }
 
-$InstallDir = if ($env:INSTALL_DIR) { $env:INSTALL_DIR } else { "." }
+# Resolve directories
+$BlanketRoot = Join-Path $env:LOCALAPPDATA "blanket"
+$InstallDir = if ($env:INSTALL_DIR) { $env:INSTALL_DIR } else { Join-Path $BlanketRoot "bin" }
+$ConfigDir = $BlanketRoot
+$TypesDir = Join-Path $BlanketRoot "types"
+$ResultsDir = Join-Path $BlanketRoot "results"
+
 $Url = "https://github.com/$Repo/releases/download/$Version/$Binary"
 $OutFile = Join-Path $InstallDir "blanket.exe"
 
-Write-Host "Installing blanket $Version (windows/amd64) to $OutFile ..."
+Write-Host "Installing blanket $Version (windows/amd64) ..."
+Write-Host "  binary:  $OutFile"
+Write-Host "  config:  $ConfigDir\"
+Write-Host "  data:    $BlanketRoot\"
+Write-Host ""
 
-if (-not (Test-Path $InstallDir)) {
-    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+# Download binary
+foreach ($dir in @($InstallDir, $TypesDir, $ResultsDir)) {
+    if (-not (Test-Path $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
 }
 
 try {
@@ -41,4 +58,67 @@ try {
     exit 1
 }
 
-Write-Host "Done. Run '$OutFile --help' to get started."
+# Write default config if not present
+$ConfigFile = Join-Path $ConfigDir "config.json"
+if (-not (Test-Path $ConfigFile)) {
+    $TypesAbs = (Resolve-Path $TypesDir).Path
+    $ResultsAbs = (Resolve-Path $ResultsDir).Path
+    $config = @{
+        port = 8773
+        tasks = @{
+            typesPaths = @($TypesAbs)
+            resultsPath = $ResultsAbs
+        }
+        logLevel = "info"
+    } | ConvertTo-Json -Depth 3
+    Set-Content -Path $ConfigFile -Value $config -Encoding UTF8
+    Write-Host "Created default config: $ConfigFile"
+} else {
+    Write-Host "Config already exists, skipping: $ConfigFile"
+}
+
+# Download example task types (skip existing files)
+Write-Host ""
+foreach ($typeFile in $ExampleTypes) {
+    $dest = Join-Path $TypesDir $typeFile
+    if (Test-Path $dest) {
+        Write-Host "  skip (exists): $typeFile"
+        continue
+    }
+
+    $typeUrl = "$RawBase/examples/types/$typeFile"
+    try {
+        Invoke-WebRequest -Uri $typeUrl -OutFile $dest -UseBasicParsing
+    } catch {
+        Write-Host "  warn: could not download $typeFile"
+        continue
+    }
+
+    # Check if executor is available
+    $executorLine = Select-String -Path $dest -Pattern '^executor' | Select-Object -First 1
+    $executor = "bash"
+    if ($executorLine) {
+        if ($executorLine.Line -match '"([^"]+)"') {
+            $executor = $Matches[1]
+        }
+    }
+    $found = Get-Command $executor -ErrorAction SilentlyContinue
+    if ($found) {
+        Write-Host "  installed: $typeFile (executor: $executor)"
+    } else {
+        Write-Host "  installed: $typeFile (warning: executor '$executor' not found on PATH)"
+    }
+}
+
+# PATH hint
+Write-Host ""
+$pathDirs = $env:PATH -split ";"
+if ($pathDirs -notcontains $InstallDir) {
+    Write-Host "Note: $InstallDir is not on your PATH. Add it with:"
+    Write-Host "  `$env:PATH = `"$InstallDir;`$env:PATH`""
+    Write-Host "  # Or permanently via System Properties > Environment Variables"
+    Write-Host ""
+}
+
+Write-Host "Done! Run 'blanket.exe --help' to get started."
+Write-Host "The server will use config from: $ConfigFile"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,16 +2,19 @@
 set -e
 
 # Install blanket — downloads the latest (or pinned) release binary for
-# Linux or macOS.
+# Linux or macOS, creates XDG-compliant config/data directories, and
+# downloads example task types.
 #
 # Usage:
 #   curl -sSfL https://raw.githubusercontent.com/turtlemonvh/blanket/master/scripts/install.sh | bash
 #
 # Environment variables:
 #   VERSION      — tag to install (default: latest release, e.g. v0.1.0)
-#   INSTALL_DIR  — directory to place the binary (default: current directory)
+#   INSTALL_DIR  — directory to place the binary (default: ~/.local/bin)
 
 REPO="turtlemonvh/blanket"
+RAW_BASE="https://raw.githubusercontent.com/$REPO/master"
+EXAMPLE_TYPES="echo_task.toml bash_task.toml python_hello.toml windows_echo.toml"
 
 # Detect OS
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -47,11 +50,21 @@ if [ -z "$VERSION" ]; then
   fi
 fi
 
-INSTALL_DIR="${INSTALL_DIR:-.}"
+# Resolve directories
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/blanket"
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/blanket"
+
 URL="https://github.com/$REPO/releases/download/$VERSION/$BINARY"
 
-echo "Installing blanket $VERSION ($OS/amd64) to $INSTALL_DIR/blanket ..."
+echo "Installing blanket $VERSION ($OS/amd64) ..."
+echo "  binary:  $INSTALL_DIR/blanket"
+echo "  config:  $CONFIG_DIR/"
+echo "  data:    $DATA_DIR/"
+echo
 
+# Download binary
 mkdir -p "$INSTALL_DIR"
 
 HTTP_CODE=$(curl -sSL -w "%{http_code}" -o "$INSTALL_DIR/blanket" "$URL")
@@ -64,4 +77,67 @@ fi
 
 chmod +x "$INSTALL_DIR/blanket"
 
-echo "Done. Run '$INSTALL_DIR/blanket --help' to get started."
+# Create config and data directories
+mkdir -p "$CONFIG_DIR" "$DATA_DIR/types" "$DATA_DIR/results"
+
+# Write default config if not present
+if [ ! -f "$CONFIG_DIR/config.json" ]; then
+  TYPES_ABS=$(cd "$DATA_DIR/types" && pwd)
+  RESULTS_ABS=$(cd "$DATA_DIR/results" && pwd)
+  cat > "$CONFIG_DIR/config.json" <<CONF
+{
+  "port": 8773,
+  "tasks": {
+    "typesPaths": ["$TYPES_ABS"],
+    "resultsPath": "$RESULTS_ABS"
+  },
+  "logLevel": "info"
+}
+CONF
+  echo "Created default config: $CONFIG_DIR/config.json"
+else
+  echo "Config already exists, skipping: $CONFIG_DIR/config.json"
+fi
+
+# Download example task types (skip existing files)
+echo
+for TYPE_FILE in $EXAMPLE_TYPES; do
+  DEST="$DATA_DIR/types/$TYPE_FILE"
+  if [ -f "$DEST" ]; then
+    echo "  skip (exists): $TYPE_FILE"
+    continue
+  fi
+
+  TYPE_URL="$RAW_BASE/examples/types/$TYPE_FILE"
+  HTTP_CODE=$(curl -sSL -w "%{http_code}" -o "$DEST" "$TYPE_URL")
+  if [ "$HTTP_CODE" -ne 200 ]; then
+    rm -f "$DEST"
+    echo "  warn: could not download $TYPE_FILE (HTTP $HTTP_CODE)"
+    continue
+  fi
+
+  # Check if executor is available
+  EXECUTOR=$(grep '^executor' "$DEST" | head -1 | sed 's/.*=.*"\(.*\)".*/\1/')
+  if [ -z "$EXECUTOR" ]; then
+    EXECUTOR="bash"
+  fi
+  if command -v "$EXECUTOR" >/dev/null 2>&1; then
+    echo "  installed: $TYPE_FILE (executor: $EXECUTOR)"
+  else
+    echo "  installed: $TYPE_FILE (warning: executor '$EXECUTOR' not found on PATH)"
+  fi
+done
+
+# PATH hint
+echo
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*) ;;
+  *)
+    echo "Note: $INSTALL_DIR is not on your PATH. Add it with:"
+    echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+    echo
+    ;;
+esac
+
+echo "Done! Run 'blanket --help' to get started."
+echo "The server will use config from: $CONFIG_DIR/config.json"

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -62,8 +62,18 @@ func (t *Task) GetCmd(tt *TaskType) (*exec.Cmd, error) {
 		return cmd, err
 	}
 
-	// FIXME: Don't just use bash; use python, zsh, etc
-	cmd = exec.Command("bash", "-c", cmdString.String())
+	executor := tt.Config.GetString("executor")
+	if executor == "" {
+		executor = "bash"
+	}
+	switch executor {
+	case "cmd":
+		cmd = exec.Command("cmd", "/c", cmdString.String())
+	case "powershell":
+		cmd = exec.Command("powershell", "-Command", cmdString.String())
+	default:
+		cmd = exec.Command(executor, "-c", cmdString.String())
+	}
 
 	// Modify execution environment with env variables
 	// e.g. http://craigwickesser.com/2015/02/golang-cmd-with-custom-environment/


### PR DESCRIPTION
## Summary

- **Install scripts** now create XDG-compliant config/data dirs, write a default `config.json`, download example task types (skip existing, validate executors), install binary to `~/.local/bin` (Linux/macOS) or `%LOCALAPPDATA%\blanket\bin` (Windows), and print PATH hints
- **Executor field functional** — `tasks/tasks.go:GetCmd()` now dispatches based on the TOML `executor` field (`cmd`, `powershell`, or any `-c` executor) instead of hardcoding bash
- **`blanket task-validate`** — new CLI command that checks all task types for runnable executors and non-empty commands
- **`windows_echo`** example type using `cmd` executor so Windows users always have something that works
- **Version format** — `blanket v0.1.0 (built 2026-05-01 11:14 PM EDT)` for tagged releases, with `BUILD_DATE` passed through Makefile ldflags and release workflow
- **README restructured** — user-facing only; dev content moved to `CONTRIBUTORS.md`, historical content to `docs/design.md`; `CLAUDE.md` trimmed to reference `CONTRIBUTORS.md`

## Test plan

- [x] `go build ./...` compiles clean
- [x] `make check-fmt` passes
- [x] `go test ./...` all pass
- [x] `make linux && bash scripts/smoke.sh` passes
- [x] Cross-compile (`make darwin windows`) succeeds with space-containing BUILD_DATE
- [x] `blanket version` shows correct dev format
- [x] `blanket task-validate` shows executor status table
- [ ] CI (docker-test, docker-test-smoke, docker-test-browser) passes
- [ ] After merge + tag: `blanket version` shows tag + build date

🤖 Generated with [Claude Code](https://claude.com/claude-code)