### PR TITLE
Drop logging hygiene NextUp item — premise was inaccurate

### DIFF
--- a/docs/next_up.md
+++ b/docs/next_up.md
@@ -135,9 +135,6 @@ The HTMX + Go-template UI is now the only UI (Phase C complete — Angular,
 
 Bigger bodies of work. Pick one when Phase 1 cleanup and test expansion wrap.
 
-- **Logging hygiene** — codebase mixes `log.Printf` (stdlib) and
-  `log "github.com/sirupsen/logrus"`. Unify on one logger (likely logrus or
-  move to `log/slog` now that we're on Go 1.23). Low risk, good readability win.
 - **ID type refactor** — replace `objectid.ObjectId` with local `TaskID` /
   `WorkerID` newtypes. Removes the MongoDB-era leak and lets us change the
   underlying ID scheme without API churn. Caveat: breaks wire format and


### PR DESCRIPTION
## Summary

Survey turned up zero stdlib `log.Printf` usage in production code — all ~84 call sites across 17 files already use logrus (aliased as `log`). The only stdlib `log` is in `lib/tailed_file/tailed_file_test.go` for test diagnostics. The "unify the loggers" framing didn't match reality.

Migrating logrus → `log/slog` is a separable, larger decision with no forcing function today (logrus 1.9.3 is stable and active; ~84 call sites + a custom `ginLogger` middleware to port). Parking it. If we later have a concrete trigger (OpenTelemetry, dep cleanup, a Go upgrade snag) we can add a fresh entry framed around that.

## Test plan

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)